### PR TITLE
Restrict includes to PROJECT/etc/apache/conf.d only

### DIFF
--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -144,7 +144,7 @@ define projects::project::apache::vhost (
     logroot             => "${::projects::basedir}/${projectname}/var/log/httpd",
     additional_includes =>
       ["${::projects::basedir}/${projectname}/etc/apache/conf.d/*.conf",
-      "${::projects::basedir}/${projectname}/etc/apache/conf.d/${title}/"],
+      "${::projects::basedir}/${projectname}/etc/apache/conf.d/${title}/*.conf"],
     ssl_cert            =>
       "${::projects::basedir}/${projectname}/etc/ssl/certs/${vhost_name}.crt",
     ssl_key             =>

--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -143,7 +143,7 @@ define projects::project::apache::vhost (
     docroot             => "${::projects::basedir}/${projectname}/var/www",
     logroot             => "${::projects::basedir}/${projectname}/var/log/httpd",
     additional_includes =>
-      ["${::projects::basedir}/${projectname}/etc/apache/conf.d/",
+      ["${::projects::basedir}/${projectname}/etc/apache/conf.d/*.conf",
       "${::projects::basedir}/${projectname}/etc/apache/conf.d/${title}/"],
     ssl_cert            =>
       "${::projects::basedir}/${projectname}/etc/ssl/certs/${vhost_name}.crt",


### PR DESCRIPTION
Complicated story behind this, but it's revealed a minor issue with the current set up. We have a set up like this:

```
PROJECT/etc/apache/conf.d
PROJECT/etc/apache/conf.d/project
PROJECT/etc/apache/conf.d/project_ssl
```

The idea is that we can have project wide configuration in conf.d and, say, ssl specific bits in project_ssl.

However the configuration looks like:

```
  ## Load additional static includes
  Include "<PROJECT>/etc/apache/conf.d/"
```

which includes that directory _and_ subdirectories, which defeats the point of the subdirectories.

This uses a wildcard at the top level, which will prevent the inclusion of subdirs.
