### PR TITLE
Use optional includes for apache config snippets

### DIFF
--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -138,20 +138,21 @@ define projects::project::apache::vhost (
   }
 
   ::apache::vhost { $title:
-    port                => $port,
-    ssl                 => $ssl,
-    docroot             => "${::projects::basedir}/${projectname}/var/www",
-    logroot             => "${::projects::basedir}/${projectname}/var/log/httpd",
-    additional_includes =>
+    port                  => $port,
+    ssl                   => $ssl,
+    docroot               => "${::projects::basedir}/${projectname}/var/www",
+    logroot               => "${::projects::basedir}/${projectname}/var/log/httpd",
+    use_optional_includes => true,
+    additional_includes   =>
       ["${::projects::basedir}/${projectname}/etc/apache/conf.d/*.conf",
       "${::projects::basedir}/${projectname}/etc/apache/conf.d/${title}/*.conf"],
-    ssl_cert            =>
+    ssl_cert              =>
       "${::projects::basedir}/${projectname}/etc/ssl/certs/${vhost_name}.crt",
-    ssl_key             =>
+    ssl_key               =>
       "${::projects::basedir}/${projectname}/etc/ssl/private/${vhost_name}.key",
-    serveraliases      => $altnames,
-    access_log_env_var => "!forwarded",
-    custom_fragment    => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
+    serveraliases         => $altnames,
+    access_log_env_var    => "!forwarded",
+    custom_fragment       => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
 SetEnvIf X-Forwarded-For \"^.*\..*\..*\..*\" forwarded
 CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded"
 


### PR DESCRIPTION
The current config fails to restart apache if no `.conf` file exists. Use `IncludeOptional` instead to fix this.
