### PR TITLE
Add missing dependency on camptocamp-openssl

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     {"name":"puppetlabs-mysql","version_requirement":">= 3.4.0"},
     {"name":"puppetlabs-concat","version_requirement":">= 1.2.3"},
     {"name":"puppetlabs-apache","version_requirement":">= 1.5.0"},
-    {"name":"puppetlabs-apache","version_requirement":">= 1.5.0"},
+    {"name":"camptocamp-openssl","version_requirement":">= 1.5.1"},
     {"name":"puppetlabs-tomcat","version_requirement":">= 1.3.0"},
     {"name":"saz-sudo","version_requirement":">= 3.1.0"}
   ]


### PR DESCRIPTION
SSL support requires camptocamp-openssl module, so add dependency on this.
