### PR TITLE
Fix for multiple projects with same user

### DIFF
--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -28,7 +28,8 @@ define projects::project (
       members => $users,
     }
 
-    project_user { $users:
+    $hacked_users = prefix($users, "${title} group member ")
+    project_user { $hacked_users:
       group => $title
     }
 
@@ -96,7 +97,8 @@ define projects::project (
 define project_user (
   $group = undef
 ) {
-  User <| title == $title |> {
+  $user = regsubst($title, "^.* group member (.*)$", '\1')
+  User <| title == $user |> {
     groups +> $group,
   }
 }


### PR DESCRIPTION
This is a horrible hack to allow passing the $users array to the project_user definition without causing multiple definitions when the same user is applied to multiple projects.  A nicer fix is available via looping when using Puppet 4 or the future parser, but this will do for now.
