### PR TITLE
Use vhost_name as vhost servername parameter, so that the SSL hosts get the correct name

### DIFF
--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -138,6 +138,7 @@ define projects::project::apache::vhost (
   }
 
   ::apache::vhost { $title:
+    servername          => $vhost_name,
     port                => $port,
     ssl                 => $ssl,
     docroot             => "${::projects::basedir}/${projectname}/var/www",


### PR DESCRIPTION
Changes the output file to use the intended vhost name instead of the section title:
-  ServerName site.example.com-ssl
-  ServerName site.example.com
