### PR TITLE
Use mod_remoteip instead of messing with X-Forwarded-For header

### DIFF
--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -152,12 +152,8 @@ define projects::project::apache::vhost (
     ssl_key             =>
       "${::projects::basedir}/${projectname}/etc/ssl/private/${vhost_name}.key",
     serveraliases       => $altnames,
-    access_log_env_var  => "!forwarded",
-    custom_fragment     => "LogFormat \"%{X-Forwarded-For}i %l %u %t \\\"%r\\\" %s %b \\\"%{Referer}i\\\" \\\"%{User-Agent}i\\\"\" proxy
-SetEnvIf X-Forwarded-For \"^.*\..*\..*\..*\" forwarded
-CustomLog \"${::projects::basedir}/${projectname}/var/log/httpd/${title}_access.log\" proxy env=forwarded"
-
-
+    # Use mod_remoteip for client IP if available:
+    access_log_format   => '%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"',
   }
 
   if $ssl == true {


### PR DESCRIPTION
Use mod_remoteip to set client IP (in %a for log format use) rather than doing anything with X-Forwarded-For directly.  %a also works when mod_remoteip is not in use, and gives the normal result, so this is simpler and should be better all round  :)

Also note that X-Forwarded-For shouldn't be trusted when not behind a proxy, as it's easily spoofed.
mod_remoteip allows you to set the allowed IPs for trust, via these settings if loaded:

```
RemoteIPHeader X-Forwarded-For
RemoteIPInternalProxy 1.2.3.4
RemoteIPInternalProxy 6.7.8.9
```

..etc
