### PR TITLE
Use dport on firewall rule, otherwise we allow source ports as well.

### DIFF
--- a/manifests/project/apache.pp
+++ b/manifests/project/apache.pp
@@ -226,7 +226,7 @@ define projects::project::apache::vhost (
 
   if !defined(Firewall["050 accept Apache ${port}"]) {
     firewall { "050 accept Apache ${port}":
-      port   => $port,
+      dport  => $port,
       proto  => tcp,
       action => accept,
     }


### PR DESCRIPTION
(self-explanatory change :)
